### PR TITLE
Replace call to pandas's deprecated method

### DIFF
--- a/MuPeXI.py
+++ b/MuPeXI.py
@@ -1159,7 +1159,7 @@ def write_output_file(peptide_info, expression, net_mhc, unique_alleles, cancer_
 
     # Sort, round up prioritization score
     print_ifnot_webserver('\tSorting output file', webserver)
-    df_sorted = df.sort(columns = ('priority_Score'), ascending=False)
+    df_sorted = df.sort_values('priority_Score', ascending=False)
     df_sorted.loc[:,'priority_Score'] = df_sorted.priority_Score.multiply(100).round().astype(int)
     df_sorted.loc[:,'Mismatches'] = df_sorted.Mismatches.astype(int)
 


### PR DESCRIPTION
The method pandas.DataFrame.sort_values replaced pandas.DataFrame.sort from pandas's version 0.17.0, and the call to the deprecated method was causing a bug preventing the writing of MuPeXI output files in environment with up-to-date versions of pandas (bug observed with pandas 0.20.1 but not with pandas 0.18.1).