### PR TITLE
Permitting console users to specify fork and assembly; minor bug fixes at the VEP stage

### DIFF
--- a/MuPeXI.py
+++ b/MuPeXI.py
@@ -187,12 +187,13 @@ def check_vcf_file(vcf_file, liftover, assembly, webserver):
         if not first_line.startswith('##fileformat=VCF'):
             usage(); sys.exit('ERROR: {} file is not a VCF file\n'.format(vcf_file))
         for line in f.readlines():
-            if '##reference' in line:
-                if 'GRCh37' in line or 'hg19' in line or 'HG19' in line:
-                    if liftover == None and assembly == "GRCh38":
-                        usage(); sys.exit('ERROR: The VCF file is aligned to HG19 / GRCh37\nINFO: {}\nINFO: Please run NGS analysis aligning to GRCh38, use the hg19 liftover option (-g/--hg19), or the GRCh37 prediction option (-a/ --assembly GRCh37)\n'.format(line.strip()))
-                    else :
-                        continue
+            if not Webserver == None:
+                if '##reference' in line:
+                    if 'GRCh37' in line or 'hg19' in line or 'HG19' in line:
+                        if liftover == None and assembly == "GRCh38":
+                            usage(); sys.exit('ERROR: The VCF file is aligned to HG19 / GRCh37\nINFO: {}\nINFO: Please run NGS analysis aligning to GRCh38, use the hg19 liftover option (-g/--hg19), or the GRCh37 prediction option (-a/ --assembly GRCh37)\n'.format(line.strip()))
+                        else :
+                            continue
             if '#CHROM' in line:
                 break
             elif not line.startswith('##'):

--- a/MuPeXI.py
+++ b/MuPeXI.py
@@ -465,9 +465,9 @@ def extract_allele_frequency(vcf_sorted_file, webserver, variant_caller):
 def run_vep(vcf_sorted_file, webserver, tmp_dir, vep_path, vep_dir, keep_tmp, file_prefix, outdir, assembly, fork):
     print_ifnot_webserver('\tRunning VEP', webserver)
     vep_file = NamedTemporaryFile(delete = False, dir = tmp_dir)
-
-    p1 = subprocess.Popen([vep_path, 
-        '-fork', chr(fork), 
+    popen_args = [
+        vep_path, 
+        '-fork', str(fork), 
         '--offline', 
         '--quiet', 
         '--assembly', assembly, 
@@ -476,7 +476,9 @@ def run_vep(vcf_sorted_file, webserver, tmp_dir, vep_path, vep_dir, keep_tmp, fi
         '-i', vcf_sorted_file.name, 
         '--force_overwrite',
         '--symbol', # print gene symbol in output  
-        '-o', vep_file.name], 
+        '-o', vep_file.name]
+
+    p1 = subprocess.Popen(popen_args,
         stdout = subprocess.PIPE,
         stderr = subprocess.PIPE)
     p1.communicate()
@@ -509,7 +511,7 @@ def build_vep_info(vep_file, webserver):
                 continue
             if 'stop' in line:
                 continue
-            line = line.split()
+            line = line.split('\t')
             # save relevant information from line 
             mutation_consequence = line[6].split(',')[0].strip()
             chr_, genome_pos = line[1].split(':')

--- a/MuPeXI.py
+++ b/MuPeXI.py
@@ -187,7 +187,7 @@ def check_vcf_file(vcf_file, liftover, assembly, webserver):
         if not first_line.startswith('##fileformat=VCF'):
             usage(); sys.exit('ERROR: {} file is not a VCF file\n'.format(vcf_file))
         for line in f.readlines():
-            if not Webserver == None:
+            if not webserver == None:
                 if '##reference' in line:
                     if 'GRCh37' in line or 'hg19' in line or 'HG19' in line:
                         if liftover == None and assembly == "GRCh38":

--- a/MuPeXI.py
+++ b/MuPeXI.py
@@ -467,7 +467,7 @@ def run_vep(vcf_sorted_file, webserver, tmp_dir, vep_path, vep_dir, keep_tmp, fi
     vep_file = NamedTemporaryFile(delete = False, dir = tmp_dir)
 
     p1 = subprocess.Popen([vep_path, 
-        '-fork', fork, 
+        '-fork', chr(fork), 
         '--offline', 
         '--quiet', 
         '--assembly', assembly, 

--- a/MuPeXI.py
+++ b/MuPeXI.py
@@ -1563,8 +1563,8 @@ def read_options(argv):
     print_mismatch = 'Yes' if '-M' in opts.keys() else None
     liftover = 'Yes' if '-g' in opts.keys() else None
     num_mismatches = opts['-m'] if '-m' in opts.keys() else 4
-    assembly = opts['-a'] if '-a' in opt.keys() else 'GRCh38'
-    fork = opts['-F'] if '-F' in opt.keys() else 1
+    assembly = opts['-a'] if '-a' in opts.keys() else 'GRCh38'
+    fork = opts['-F'] if '-F' in opts.keys() else 1
 
 
     # Create and fill input named-tuple

--- a/doc/MuPeXI_User_Manual.md
+++ b/doc/MuPeXI_User_Manual.md
@@ -186,7 +186,8 @@ All options can be explored using the usage information with the `-h` option:
                                 by -o or -L.
         -L, --log-file          Logfile name.                                       <VCF-file>.log
         -m, --mismatch-number   Maximum number of mismatches to search for in       4
-                                normal peptide match. 
+                                normal peptide match.
+        -a, --assembly          The assembly version to run VEP.                    GRCh38
 
         Other options (these do not take values)
         -f, --make-fasta        Create FASTA file with long peptides 
@@ -196,7 +197,7 @@ All options can be explored using the usage information with the `-h` option:
         -M, --mismatch-only     Print only mismatches in normal peptide sequence 
                                 and otherwise use dots (...AA.....)
         -w, --webface           Run in webserver mode
-        -g, --hg19              Perform liftover HG19 to GRCh38.
+        -g, --liftover          Perform liftover HG19 to GRCh38.
                                 Requires local picard installation with paths
                                 stated in the config file
         -E, --expression-type   Setting if the expression values in the expression  transcript

--- a/doc/MuPeXI_User_Manual.md
+++ b/doc/MuPeXI_User_Manual.md
@@ -188,6 +188,9 @@ All options can be explored using the usage information with the `-h` option:
         -m, --mismatch-number   Maximum number of mismatches to search for in       4
                                 normal peptide match.
         -a, --assembly          The assembly version to run VEP.                    GRCh38
+                
+        Optional arguments affecting computational process:
+        -F, --fork              Number of processors running VEP.                   1
 
         Other options (these do not take values)
         -f, --make-fasta        Create FASTA file with long peptides 


### PR DESCRIPTION
Feature changes:
- Allows console mode users to use VEP in native GRCh37 mode. This includes the following edits:
  - Adding the `-A/ --assembly` argument, defaulting to `'GRCh38'`, that allows the user to specify the genome assembly during VEP;
  - The long form of the `-g` argument is changed to `--liftOver` to avoid confusion as for its purpose;
  - The assembly used in the VCF input is only checked in the webserver mode, per @ambj 's suggestions.
- Adding the argument `-F/--fork` with a default of 1 to control the number of forks used in VEP. The previous hard-coded default of 5 may be excessive in some configurations.

Bug fixes:
- VEP may introduce spaces between the colon and the chromosomal location in the `Location` field, so `build_vep_info` is changed to ensure all output lines were split correctly.