### PR TITLE
expand environment variables in paths

### DIFF
--- a/MuPeXI.py
+++ b/MuPeXI.py
@@ -165,7 +165,7 @@ def config_parse(config_file, category, ID):
     # parse config file
     config = SafeConfigParser()
     config.read(config_file)
-    path = config.get(category, ID) if config.has_option(category, ID) else None
+    path = os.path.expandvars(config.get(category, ID)) if config.has_option(category, ID) else None
 
     return path
 


### PR DESCRIPTION
when running MuPeXI in different (remote) environments, users don't always know the exact path of the executables and biological data.
allowing for environment variables in the paths makes it possible to use the same `config.ini` for all environments.