### PR TITLE
Fix bug in parsing VEP output when aa change goes from 'X' to 'X'

### DIFF
--- a/MuPeXI.py
+++ b/MuPeXI.py
@@ -597,6 +597,9 @@ def build_vep_info(vep_file, webserver):
             prot_pos = line[9].strip()
             cdna_pos = line[7].strip()
             symbol = re.search(r'SYMBOL=(\d*\w*\d*\w*\d*\w*)', line[13]).group(1).strip() if not re.search(r'SYMBOL', line[13]) == None else '-'
+            if not '/' in line[10] :
+                # Can happen if aa goes from X to X (i.e. Mmus:11_60207188_C/- on e!97 ENSMUST00000134660.7, a truncated gene model)
+                continue
             aa_normal, aa_mutation = line[10].split('/')
             codon_normal, codon_mut = line[11].split('/')
             if '-' in line[9] :


### PR DESCRIPTION
This is likely to be a very rare bug but happens for instance with Mmus:11:60207188:C/- on e!97, which affects ENSMUST00000134660.7 among others. This is a truncated transcript and the mutation lands on the first annotated codon (which is truncated) resulting in NGT codon changing to NT and being encoded as an X/X amino acid change. The Ensembl variation API only returns the new amino acid when both the REF and ALT are identical.

While in this case, the mutation is likely to generate a non-synonymous mutation, both REF and ALT amino acids are undetermined and are therefore represented with an 'X'.